### PR TITLE
RSpec dependency made optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@ source :rubygems
 gem 'rake'
 gem 'git', '>= 1.0.5'
 
-group :ticgitweb do
+group :web do
   gem 'sinatra'
   gem 'haml'
 end
 
-group :development do
+group :dev do
  gem 'rspec', '>= 2.0.0.beta.22'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source :rubygems
 
 gem 'rake'
-gem 'rspec', '~> 2.0'
 gem 'git', '>= 1.0.5'
-gem 'sinatra'
-gem 'haml'
+
+group :ticgitweb do
+  gem 'sinatra'
+  gem 'haml'
+end
+
+group :development do
+ gem 'rspec', '~> 2.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ group :ticgitweb do
 end
 
 group :development do
- gem 'rspec', '~> 2.0'
+ gem 'rspec', '>= 2.0.0.beta.22'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,5 +26,5 @@ DEPENDENCIES
   git (>= 1.0.5)
   haml
   rake
-  rspec (~> 2.0)
+  rspec (>= 2.0.0.beta.22)
   sinatra

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
-require 'rubygems'
-require 'bundler'
-
-unless system 'bundle check'
-  exit 1 unless system 'bundle install'
+# Ensure that the basics are installed before doing anything more
+# complicated.
+%w[rubygems bundler].each do |gem|
+  begin
+    require gem
+  rescue LoadError
+    $stderr.puts 'Missing gem: ' << gem
+    $load_error = true
+  end
 end
+exit 1 if $load_error
 
 require 'bundler/setup'
 require 'rake/gempackagetask'


### PR DESCRIPTION
It should be possible for the source tree and rake tasks to be used without an excessive number of dependencies. I've broken the dependency handling up so that rake can run without RSpec already installed, while Bundler still handles the dependencies.
