### PR TITLE
Gemspec relative include

### DIFF
--- a/ticgit-ng.gemspec
+++ b/ticgit-ng.gemspec
@@ -1,7 +1,7 @@
 lib= File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
-require 'lib/ticgit-ng'
+require './lib/ticgit-ng'
 
 Gem::Specification.new do |s|
   s.name      = "TicGit-ng"


### PR DESCRIPTION
Here's a slight change that fixes "gem build" for me on both 1.8.7 and 1.9.2. Without the relative path, both fail for me.
