### PR TITLE
Set @out early so we can print errors

### DIFF
--- a/lib/ticgit-ng/cli.rb
+++ b/lib/ticgit-ng/cli.rb
@@ -20,10 +20,10 @@ module TicGitNG
     attr_accessor :out
 
     def initialize(args, path = '.', out = $stdout)
+      @out = out
       @args = args.dup
       @tic = TicGitNG.open(path, :keep_state => true)
       @options = OpenStruct.new
-      @out = out
 
       @out.sync = true # so that Net::SSH prompts show up
     rescue NoRepoFound


### PR DESCRIPTION
I'm just starting to play around with TicGit and ran into the error that using "ti" in a non git directory gives an error.

This commit sets @out early so when we try to print an error message on line 30 (using the puts method on line 235) it works.
