### PR TITLE
Updated Install for Debian and Ubuntu

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -32,6 +32,10 @@ To install these packages on a Debian system, or a Debian based system like Ubun
     sudo apt-get install git ruby rubygems
     sudo gem install git
 
+After installing Gems it is necessary to update the PATH environment variable so that the scripts can be found. Issue the following command to the end of your .bachrc file or equivalent.
+
+    PATH=$PATH:/var/lib/gems/1.8/bin
+
 **ticgitweb**
 
 Required Packages: git, ruby, rubygems
@@ -43,8 +47,6 @@ To install these packages on a Debian system, or a Debian based system like Ubun
     sudo apt-get install git ruby rubygems
     sudo gem install git sinatra haml
     sudo gem install sass --pre
-
-
 
 **A Note about rubygems**
 
@@ -60,14 +62,15 @@ The git gem requires a git version of 1.6.0.0 or later, but on Debian stable, gi
 
 If these annoy you as they do me and you've set up [apt](http://jaqque.sbih.org/kplug/apt-pinning.html) [pinning](http://jeffwelling.github.com//2010/09/05/Apt-Pinning.html), you can do
 
-    $ sudo apt-get -t testing install git-core
+    sudo apt-get -t testing install git-core
 
 And those notices should go away.
 
-NB Ubuntu is already at Git 1.7 and does not have this issue. However the Git PPA [ppa:git-core/ppa](https://launchpad.net/~git-core/+archive/ppa) can be added to the package repository
-list to obtain Git updates if wanted.
+**A Note about Ubuntu**
 
+NB At the time of writing (Ver 1.0.2.3) there are additional problems with TigGitWeb Ubuntu. The workaround is to add `/var/lib/gems/1.8/gems/TicGit-ng-1.0.2.3/bin` to start of PATH. viz
 
+    PATH=/var/lib/gems/1.8/gems/TicGit-ng-1.0.2.3/bin:$PATH
 
 ### Installing ##
 Installation on a Debian stable system.  Note that the command line interface for TicGit-ng can be run from Debian stable, but some of the gems required for the web interface may require you to use [apt](http://jaqque.sbih.org/kplug/apt-pinning.html) [pinning](http://jeffwelling.github.com//2010/09/05/Apt-Pinning.html) to run without errors.  See below


### PR DESCRIPTION
1) Tidied up examples
2) Added intructions on setting path to gems
3) Added workaround for Ubuntu (see issue https://github.com/jeffWelling/ticgit/issues/19)
