### PR TITLE
Fix cli tests

### DIFF
--- a/bin/ti
+++ b/bin/ti
@@ -5,7 +5,7 @@ require 'fileutils'
 # Add the library from the source tree to the front of the load path.
 # This allows ti to run without first installing a ticgit gem, which is
 # important when testing multiple branches of development.
-if File.exist? File.join('lib', 'ticgit-ng.rb')
+if File.exist? File.join(File.dirname(__FILE__), '..', 'lib', 'ticgit-ng.rb')
     $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 end
 require 'ticgit-ng'

--- a/lib/ticgit-ng/command.rb
+++ b/lib/ticgit-ng/command.rb
@@ -41,7 +41,10 @@ module TicGitNG
       o.top.append ' ', nil, nil
       o.top.append 'The available ticgit commands are:', nil, nil
 
-      DOC.each do |commands, doc|
+      sorted_doc = DOC.sort_by do |cmds, doc|
+        cmds.sort_by{|cmd| cmd.size }.last
+      end
+      sorted_doc.each do |commands, doc|
         # get the longest version
         command = commands.sort_by{|cmd| cmd.size }.last
         o.top.append("    %-32s %s" % [command, doc], nil, nil)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -36,8 +36,9 @@ The available ticgit commands are:
     recent                           List recent activities
     show                             Show a ticket
     state                            Change state of a ticket
-    tag                              Modify tags of a ticket
     sync                             Sync tickets
+    tag                              Modify tags of a ticket
+    title                            Modify the title of a ticket
 
 Common options:
     -v, --version                    Show the version number


### PR DESCRIPTION
The test 'displays --help' in cli_spec.rb fails because the output of the help comes out in an order that is different than the test expects. It's occuring because the test expects the output to be in a specific order (alphabetical mostly) but my help output is listing them differently.

This patch specifically sorts the command list in alphabetical order.
