### PR TITLE
Integer SHAs now return appropriate ticket

### DIFF
--- a/lib/ticgit-ng/base.rb
+++ b/lib/ticgit-ng/base.rb
@@ -207,10 +207,8 @@ module TicGitNG
       if ticket_id
         ticket_id = ticket_id.strip
 
-        if /^[0-9]*$/ =~ ticket_id
-          if t = @last_tickets[ticket_id.to_i - 1]
-           return t
-          end
+        if /^[0-9]*$/ =~ ticket_id && (t = @last_tickets[ticket_id.to_i - 1])
+          return t
         else # partial or full sha
           regex = /^#{Regexp.escape(ticket_id)}/
           ch = tickets.select{|name, t|

--- a/lib/ticgit-ng/base.rb
+++ b/lib/ticgit-ng/base.rb
@@ -209,7 +209,7 @@ module TicGitNG
 
         if /^[0-9]*$/ =~ ticket_id && (t = @last_tickets[ticket_id.to_i - 1])
           return t
-        else # partial or full sha
+        elsif ticket_id.length > 4 # partial (5 characters or greater to be considered unique enough) or full sha
           regex = /^#{Regexp.escape(ticket_id)}/
           ch = tickets.select{|name, t|
             t['files'].assoc('TICKET_ID')[1] =~ regex }

--- a/spec/base_ticket_revparse_spec.rb
+++ b/spec/base_ticket_revparse_spec.rb
@@ -1,0 +1,76 @@
+require File.dirname(__FILE__) + "/spec_helper"
+
+describe TicGitNG::Base do
+  include TicGitNGSpecHelper
+
+  before(:each) do
+    @path = setup_new_git_repo
+    @orig_test_opts = test_opts
+    @ticgitng = TicGitNG.open(@path, @orig_test_opts)
+  end
+
+  after(:each) do
+    Dir.glob(File.expand_path("~/.ticgit-ng/-tmp*")).each {|file_name| FileUtils.rm_r(file_name, {:force=>true,:secure=>true}) }
+    Dir.glob(File.expand_path("/tmp/ticgit-ng-*")).each {|file_name| FileUtils.rm_r(file_name, {:force=>true,:secure=>true}) }
+  end
+
+  it "should return a ticket by index" do
+    @ticgitng = TicGitNG.open(@path, @orig_test_opts)
+    test_titles = ["0", "1", "2"]
+    test_titles.each do |title|
+      @ticgitng.ticket_new(title)
+    end
+
+    # This forces the ticket list to cache as an indexable list
+    # Use the middle ticket as our test ticket
+    title_index = @ticgitng.ticket_list[1].title.to_i
+
+    # Ticket indexing is 1 based. Query for the middle ticket.
+    found_tic_name = @ticgitng.ticket_revparse("2")
+    clean_name = test_titles[title_index].downcase.gsub(/[^a-z0-9]+/i, '-')
+    found_tic_name.should match /^\d+_#{clean_name}_\d+$/
+  end
+
+  it "should return a ticket by full SHA" do
+    test_title = "My SHA test ticket"
+    tic = @ticgitng.ticket_new(test_title)
+
+    found_tic_name = @ticgitng.ticket_revparse(tic.ticket_id)
+    clean_name = test_title.downcase.gsub(/[^a-z0-9]+/i, '-')
+    found_tic_name.should match /^\d+_#{clean_name}_\d+$/
+  end
+
+  it "should return a ticket by partial SHA which is an integer" do
+    test_title = "My partial integer SHA test ticket"
+    integer_partial_sha = '432513'
+
+    clean_name = test_title.downcase.gsub(/[^a-z0-9]+/i, '-')
+    @ticgitng.should_receive(:read_tickets).with().and_return(
+      {
+        "1306092232_#{clean_name}_317" =>
+          {
+            "files"=> [
+                ["ASSIGNED_dale.fukami@gmail.com", "2d4e94d6963e02f079bc5712ed90a8237a415ebf"],
+                ["STATE_open", "f510327578a4562e26a7c64bdf061e4a49f85ee6"],
+                ["TICKET_ID", integer_partial_sha+'ajf34j2lk23bk3423'],
+                ["TICKET_TITLE", "44c496d5543823f54e7920738b70b03e85955866"],
+                ["TITLE", "44c496d5543823f54e7920738b70b03e85955866"]
+            ]
+          }
+      }
+    )
+
+    found_tic_name = @ticgitng.ticket_revparse(integer_partial_sha)
+    found_tic_name.should match /^\d+_#{clean_name}_\d+$/
+  end
+
+  it "should return a ticket by partial SHA" do
+    test_title = "My partial SHA test ticket"
+    tic = @ticgitng.ticket_new(test_title)
+
+    found_tic_name = @ticgitng.ticket_revparse(tic.ticket_id[0..5])
+    clean_name = test_title.downcase.gsub(/[^a-z0-9]+/i, '-')
+    found_tic_name.should match /^\d+_#{clean_name}_\d+$/
+  end
+
+end

--- a/spec/base_ticket_revparse_spec.rb
+++ b/spec/base_ticket_revparse_spec.rb
@@ -50,7 +50,7 @@ describe TicGitNG::Base do
         "1306092232_#{clean_name}_317" =>
           {
             "files"=> [
-                ["ASSIGNED_dale.fukami@gmail.com", "2d4e94d6963e02f079bc5712ed90a8237a415ebf"],
+                ["ASSIGNED_some_person@email.com", "2d4e94d6963e02f079bc5712ed90a8237a415ebf"],
                 ["STATE_open", "f510327578a4562e26a7c64bdf061e4a49f85ee6"],
                 ["TICKET_ID", integer_partial_sha+'ajf34j2lk23bk3423'],
                 ["TICKET_TITLE", "44c496d5543823f54e7920738b70b03e85955866"],
@@ -71,6 +71,13 @@ describe TicGitNG::Base do
     found_tic_name = @ticgitng.ticket_revparse(tic.ticket_id[0..5])
     clean_name = test_title.downcase.gsub(/[^a-z0-9]+/i, '-')
     found_tic_name.should match /^\d+_#{clean_name}_\d+$/
+  end
+
+  it "should not return a ticket by short partial SHA" do
+    tic = @ticgitng.ticket_new("My short partial SHA test ticket")
+
+    found_tic_name = @ticgitng.ticket_revparse( tic.ticket_id[0..3] )
+    found_tic_name.should == nil
   end
 
 end


### PR DESCRIPTION
I was having a problem manipulating tickets when the 6 digit partial SHA had no alpha characters. This fix will fall back to the SHA check for ticket id if there is no ticket at the index requested.

Should we only check for SHA if the length is >= 6? With this fix it's possible to do the potentially dangerous: "ti state 8 close" and if there is no ticket at index 8 then it will close the first ticket that has a SHA starting with an 8.

Also note, I split the tests out to a separate file as all the tests currently in the base_spec.rb file depend on each other. This is due to the repo not being reset between tests. Rather than untangle the existing tests I figured a new file was alright. Thoughts?
