### PR TITLE
Enhance usability for ticgitweb

### DIFF
--- a/bin/ticgitweb
+++ b/bin/ticgitweb
@@ -102,11 +102,12 @@ def layout(title, content)
   %Q(
 %html
   %head
-    %title #{title}
+    %title #{File.basename(Dir.pwd)}:#{title}
     %link{:rel => 'stylesheet', :href => '/_stylesheet.css', :type => 'text/css', :media => 'screen'}
     %meta{'http-equiv' => 'Content-Type', :content => 'text/html; charset=utf-8'}
 
   %body
+    %h1 #{File.basename(Dir.pwd)} (#{Dir.pwd})
     #navigation
       %a{:href => '/'} All
       %a{:href => '/fs/open'} Open

--- a/lib/ticgit-ng/base.rb
+++ b/lib/ticgit-ng/base.rb
@@ -12,7 +12,7 @@ module TicGitNG
       @git = Git.open(find_repo(git_dir))
 
       begin
-        git.lib.full_log_commits 1
+        git.lib.full_log_commits :count => 1
       rescue
         puts "Git error: please check your git repository, you must have at least one commit in git"
         exit 1

--- a/spec/scalability_spec.rb
+++ b/spec/scalability_spec.rb
@@ -1,0 +1,58 @@
+require File.dirname(__FILE__) + "/spec_helper"
+
+describe TicGitNG::Base do
+  include TicGitNGSpecHelper
+
+  before(:each) do
+    @path = setup_new_git_repo
+    @orig_test_opts = test_opts
+    @ticgitng = TicGitNG.open(@path, @orig_test_opts)
+  end
+
+  after(:each) do
+    Dir.glob(File.expand_path("~/.ticgit-ng/-tmp*")).each {|file_name| FileUtils.rm_r(file_name, {:force=>true,:secure=>true}) }
+    Dir.glob(File.expand_path("~/.ticgit/-tmp*")).each {|file_name| FileUtils.rm_r(file_name, {:force=>true,:secure=>true}) }
+    Dir.glob(File.expand_path("/tmp/ticgit-ng-*")).each {|file_name| FileUtils.rm_r(file_name, {:force=>true,:secure=>true}) }
+  end
+
+  it "Should take the same amount of time to init on a large repo as a small one" do
+    t1_before=0
+    t1_after=0
+    t2_before=0
+    t2_after=0
+    path1= setup_new_git_repo
+    Dir.chdir( path1 ) do
+      #test a small repo
+      #do this a couple times to make it a bit fairer re caching
+      10.times do
+        t1_before=Time.now.to_i
+        ticgit1=TicGitNG.open( path1, @orig_test_opts )
+        t1_after=Time.now.to_i
+      end
+    end
+
+    path2= setup_new_git_repo
+    Dir.chdir( path2 ) do
+      #test a large repo
+      git=Git.open '.'
+      500.times do |i|
+        new_file("file_#{i}", "#{rand(9999999)}_#{i}")
+        git.add "file_#{i}"
+        git.commit "Added file_#{i}"
+      end
+      #do this a couple times to make it fairer re caching
+      10.times do
+        t2_before=Time.now.to_i
+        ticgit2=TicGitNG.open( path2, @orig_test_opts )
+        t2_after=Time.now.to_i
+      end
+    end
+    #Opening is a simple operation, it should take less than a second in most cases,
+    #But this test is intended to make sure that the size of the repo does not impact
+    #the initialization time of TicGit-ng
+    #FIXME Fix this dirty hack, find out what the proper way to do this is
+    true.should == ((t1_after-t1_before) < 5)
+    true.should == ((t2_after-t2_before) < 5)
+  end
+
+end


### PR DESCRIPTION
The web interface should show which repository is currently displayed. This is achieved by showing the directory in the title and in the html body. This is especially important if several instanced of ticgitweb are active. 
